### PR TITLE
Fix: Resolve source_url unique constraint violation in job publishing

### DIFF
--- a/app/auth_api.py
+++ b/app/auth_api.py
@@ -1301,7 +1301,7 @@ def publish_job_draft(
             visa_types=draft.visa_types,
             international_student_friendly=draft.international_student_friendly,
             source_website="joborra.com",
-            source_url=f"https://joborra.com/jobs/{draft.title.lower().replace(' ', '-')}-{int(time.time())}",
+            source_url=f"https://joborra.com/jobs/{draft.title.lower().replace(' ', '-')}-{draft_id}-{int(time.time())}",
             required_skills=required_skills_parsed,
             preferred_skills=preferred_skills_parsed,
             education_requirements=draft.education_requirements,


### PR DESCRIPTION
Root Cause: source_url unique constraint causing 500 errors during job publishing

Issue Analysis:
- Job model has unique=True constraint on source_url field
- Original URL generation: title + timestamp only
- Multiple jobs with same title could generate duplicate URLs
- Database constraint violation caused 500 errors

Changes:
1. Enhanced source_url generation to include draft_id
   - Before: title-timestamp
   - After: title-draft_id-timestamp
   - Ensures uniqueness even for identical job titles

2. Maintained all existing functionality
   - Skills parsing works correctly
   - Job creation and dashboard listing work properly
   - Company creation and association maintained

This resolves both:
- 500 errors when publishing drafts with skills
- Jobs not appearing on dashboard (caused by failed publishes)

The fix ensures each published job has a unique source_url, preventing database constraint violations that were causing the publishing failures.