### PR TITLE
Fix VEVO upload 500 error: Remove document_type parameter

### DIFF
--- a/app/visa_api.py
+++ b/app/visa_api.py
@@ -160,15 +160,12 @@ async def refresh_visa_status(
 
 @router.post("/documents/upload")
 async def upload_visa_document(
-    document_type: str,
     file: UploadFile = File(...),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
     """Upload VEVO document and store URL on the user profile (exactly like resume upload)"""
-    # Validate document type - Only allow VEVO documents
-    if document_type != 'vevo':
-        raise HTTPException(status_code=400, detail="Only VEVO documents are allowed for upload")
+    # VEVO documents only - no need for document_type parameter
     
     # Validate file type and filename (same as resume upload)
     allowed_extensions = ['.pdf']


### PR DESCRIPTION
- Removed document_type parameter from upload_visa_document endpoint
- Now matches exact signature of working resume upload endpoint
- FastAPI was expecting document_type as form field causing 500 error
- Both endpoints now have identical parameter structure and processing
- Should resolve production 500 error for VEVO uploads