### PR TITLE
Fix frontend VEVO upload: Remove document_type query parameter

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -291,7 +291,7 @@ class ApiService {
   async uploadVisaDocument(file: File): Promise<any> {
     const form = new FormData();
     form.append('file', file);
-    const response = await this.api.post(`/auth/visa/documents/upload?document_type=vevo`,
+    const response = await this.api.post(`/auth/visa/documents/upload`,
       form,
       { headers: { 'Content-Type': 'multipart/form-data' } }
     );


### PR DESCRIPTION
- Frontend was still sending document_type=vevo as query parameter
- Backend no longer expects this parameter after API simplification
- Now frontend matches backend API signature exactly
- This should resolve the 500 error in production